### PR TITLE
Fix fileName for android

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const FSStorage = (
   const baseFolder = resolvePath(location, folder);
 
   const pathForKey = (key: string) =>
-    resolvePath(baseFolder, encodeURIComponent(key));
+    resolvePath(baseFolder, key.replace(/[;\\/:*?\"<>|&']/gi,'_'));
 
   const setItem = (
     key: string,


### PR DESCRIPTION
I am discovered next issue:
keys is escaping and file name for key `root:storage` will be `root%3Astorage`.
The issue is that on android this file name stored as `persist:pdfstorage`
So `fs.exists(pathForKey(key))` where pathForKey(key) = `.../root%3Astorage`  return false for me